### PR TITLE
Fix recursion and segmentation fault issues

### DIFF
--- a/script.py
+++ b/script.py
@@ -1,10 +1,8 @@
-import sys
+#!/usr/bin/env python3
 
 import cv2  # Opencv ver 3.1.0 used
 import numpy as np
 
-# Set recursion limit
-sys.setrecursionlimit(10 ** 9)
 
 import selectinwindow
 

--- a/selectinwindow.py
+++ b/selectinwindow.py
@@ -75,7 +75,8 @@ class DragRectangle:
 
     def __init__(self, Img, windowName, windowWidth, windowHeight):
         # Image
-        self.image = Img
+        self.original = Img
+        self.image = self.original.copy()
 
         # Window name
         self.wname = windowName
@@ -124,7 +125,6 @@ def mouseDoubleClick(eX, eY, dragObj):
     if dragObj.active:
         if pointInRect(eX, eY, dragObj.outRect.x, dragObj.outRect.y, dragObj.outRect.w, dragObj.outRect.h):
             dragObj.returnflag = True
-            cv2.destroyWindow(dragObj.wname)
 
 
 def mouseDown(eX, eY, dragObj):
@@ -288,13 +288,12 @@ def straightenUpRect(dragObj):
 
 def clearCanvasNDraw(dragObj):
     # Draw
-    tmp = dragObj.image.copy()
+    tmp = dragObj.original.copy()
     cv2.rectangle(tmp, (dragObj.outRect.x, dragObj.outRect.y),
                   (dragObj.outRect.x + dragObj.outRect.w,
                    dragObj.outRect.y + dragObj.outRect.h), (0, 255, 0), 2)
     drawSelectMarkers(tmp, dragObj)
-    cv2.imshow(dragObj.wname, tmp)
-    cv2.waitKey()
+    dragObj.image = tmp
 
 
 def drawSelectMarkers(image, dragObj):


### PR DESCRIPTION
The callbacks no longer call any drawing/window functions.
Since they don't call waitKey, there's no recursion issue.
Since they don't destroy the window after a double click, there's no segmentation fault of calling imshow on a destroyed window.

This should fix issues #8 and #10 